### PR TITLE
Fixed print menu shown twice error.

### DIFF
--- a/wpnew
+++ b/wpnew
@@ -142,6 +142,7 @@ while getopts ${optstring} arg; do
     case ${arg} in
         h)
             printHelp;
+            exit 0;
             ;;
         n)
             # Check if script is ran is root and exit if it's not.


### PR DESCRIPTION
fix for the help menu printing out twice.